### PR TITLE
README.md: Remove --save-dev (-D) from npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library provides an easy way to produce and consume server sent events.
 Install with:
 
 ```sh
-npm i -D sveltekit-server-sent-events
+npm i sveltekit-server-sent-events
 ```
 
 Create your server sent event with:


### PR DESCRIPTION
As far as I'm aware the -D must be wrong here, right?
Or is there some incompatibility with some environments which is why you see this lib as a dev-only thing?