### PR TITLE
Fix: `No known conditions for "." specifier`

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -6,6 +6,7 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"moduleResolution": "NodeNext"
+		"moduleResolution": "NodeNext",
+		"module": "NodeNext"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
-			"svelte": "./dist/index.js"
+			"import": "./dist/index.js"
 		}
 	},
 	"files": [

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -1,5 +1,5 @@
-import { source } from './source'
-import { event } from './event'
+import { source } from './source.js'
+import { event } from './event.js'
 import type { Subscriber, Invalidator, Unsubscriber } from 'svelte/store'
 
 export type Producer = (emit: (data: string) => void, ping: () => void) => void | Promise<void>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,4 @@
-import { source } from './source'
-import { event } from './event'
+import { source } from './source.js'
+import { event } from './event.js'
 
 export { source, event }


### PR DESCRIPTION
When I attempt to use this module with SvelteKit v1.22.4 and Vite v4.4.9, I receive the following error:

```
Internal server error: Failed to resolve entry for package "sveltekit-server-sent-events".
The package may have incorrect main/module/exports specified in its package.json:
No known conditions for "." specifier in "sveltekit-server-sent-events" package
      at packageEntryFailure (file:///home/dsieradski/development/supplies/supplies-frontend/node_modules/vite/dist/node/chunks/dep-df561101.js:28691:11)
      at resolvePackageEntry (file:///home/dsieradski/development/supplies/supplies-frontend/node_modules/vite/dist/node/chunks/dep-df561101.js:28686:9)
      at tryNodeResolve (file:///home/dsieradski/development/supplies/supplies-frontend/node_modules/vite/dist/node/chunks/dep-df561101.js:28427:20)
      at nodeImport (file:///home/dsieradski/development/supplies/supplies-frontend/node_modules/vite/dist/node/chunks/dep-df561101.js:56002:26)
      at ssrImport (file:///home/dsieradski/development/supplies/supplies-frontend/node_modules/vite/dist/node/chunks/dep-df561101.js:55912:30)
      at eval (/home/dsieradski/development/supplies/supplies-frontend/src/routes/account/+page.server.ts:5:37)
      at async instantiateModule (file:///home/dsieradski/development/supplies/supplies-frontend/node_modules/vite/dist/node/chunks/dep-df561101.js:55974:9)
```

After searching around quite a bit, I came across some suggestions which I've implemented here, and sure enough, it's now working properly.