### PR TITLE
Encode `string` payload to `Uint8Array` to avoid `TypeError` on some runtimes

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -32,6 +32,7 @@
  */
 function createEmitter(controller) {
   let id = 1
+  const encoder = new TextEncoder()
   /** @type {function(string):void} */
   return function (eventName, data) {
     const typeOfEventName = typeof eventName
@@ -43,7 +44,7 @@ function createEmitter(controller) {
       throw new Error(`Event data must of type \`string\`, received \`${typeOfData}\`.`)
     }
     const payload = `id: ${id}\nevent: ${eventName}\ndata: ${data}\n\n`
-    controller.enqueue(new TextEncoder().encode(payload))
+    controller.enqueue(encoder.encode(payload))
     id++
   }
 }

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -43,7 +43,7 @@ function createEmitter(controller) {
       throw new Error(`Event data must of type \`string\`, received \`${typeOfData}\`.`)
     }
     const payload = `id: ${id}\nevent: ${eventName}\ndata: ${data}\n\n`
-    controller.enqueue(payload)
+    controller.enqueue(new TextEncoder().encode(payload))
     id++
   }
 }


### PR DESCRIPTION
Encode `string` to `Uint8Array` as `ReadableStream` should only accept `Uint8Array` and can triggers `TypeError` on some runtimes (see https://github.com/vercel/next.js/issues/38736#issuecomment-1278917422).

This will make it compatible with Vercel Edge Runtime.