### PR TITLE
fix(source): fix duplicate connections - remove cache, connect as store

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,11 +1,10 @@
 <script>
   import { goto } from '$app/navigation'
-  import { navigating, page } from '$app/stores'
-  let lang = $page.url.searchParams.get('lang') || 'en'
+  import { page } from '$app/stores'
 </script>
 
 <select
-  bind:value={lang}
+  value={$page.url.searchParams.get('lang') || 'en'}
   on:change={async function pick(e) {
     $page.url.searchParams.set('lang', e.currentTarget.value)
     goto(`?${$page.url.searchParams}`, {
@@ -14,22 +13,15 @@
       // If the load() function doesn't get invoked, then the #key below
       // will update the slot with the old source store, which will
       // be closed at that point.
-      invalidateAll: true,
+      invalidateAll: false,
     })
   }}
 >
   <option value="en">🇦🇺 English</option>
   <option value="it">🇮🇹 Italiano</option>
 </select>
+
 <br />
 <br />
-<!-- 
-  Using goto() will not unsubscribe from your stores, 
-  you need to force the client to unsubscribe using a #key. 
-  The $page store works just fine as a key here.
-  The $navigating store also works because 
-  it is indirectly updated by goto().
--->
-{#key $navigating}
-  <slot />
-{/key}
+
+<slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,7 +1,8 @@
 <script>
   import { enhance } from '$app/forms'
   export let data
-  const quote = data?.quote
+
+  $: quote = data?.quote
 </script>
 
 <form use:enhance method="post">


### PR DESCRIPTION
Fixes #33

## Changes

### Remove cache from `stream()`

As discussed in #33 - there was an issue with duplicate connections being made. I have stripped out a lot of code out in `stream.js`, and this has resolved this issue.

- One `source()` will always create one `connectable()`, which will call one `fetchWithProgress()`
- Many `select()` / `transform()` / `json()` can be derived and subscribed from this source

I understand this also removes a feature. Previously, users were previously able to `source()` multiple streams from the same URL, without creating duplicate beacons/fetch requests.

Perhaps that functionality could be restored by adding a cache to the `connectable()` method, or fixing the intended behaviour in `stream()` - but it is not included in this PR. (My personal perspective is it should be users responsibility to make sure they don't create two sources... but I do understand the value of including this feature).

### Rewrite internal `connect()` function to instead return `readable()`

This simplifies `source()`, and internally changes `select()` to return a derived store. Does not change the functionality for users.

### Updated example app

Removed the `{#key $navigating}` - `#key` blocks are great for re-rendering small components, but wrapping an entire layout slot is a little bit spicy in larger web apps.

Instead, we can reactively bind the store to the page data, so the store reference is updated whenever the page data changes.