### PR TITLE
chore(types): remove `timeout` from fetch options

### DIFF
--- a/src/lib/stream.js
+++ b/src/lib/stream.js
@@ -16,7 +16,7 @@ export const CLOSED = 2
 
 /**
  * Options for the underlying http request.
- * @typedef {Pick<import('@microsoft/fetch-event-source').FetchEventSourceInit, "body"|"cache"|"credentials"|"fetch"|"headers"|"integrity"|"keepalive"|"method"|"mode"|"openWhenHidden"|"redirect"|"referrer"|"referrerPolicy"|"timeout"|"window">} Options
+ * @typedef {Pick<import('@microsoft/fetch-event-source').FetchEventSourceInit, "body"|"cache"|"credentials"|"fetch"|"headers"|"integrity"|"keepalive"|"method"|"mode"|"openWhenHidden"|"redirect"|"referrer"|"referrerPolicy"|"window">} Options
  */
 
 /**


### PR DESCRIPTION
Small change to remove the "timeout" property from`Options` (derived from `Pick<FetchEventSourceInit, ...>`)

Browser fetch doesn't actually have this option, so it's type is "unknown", resulting in a TS error:

https://fetch.spec.whatwg.org/#requestinit

Resolves TS error:

> Property 'timeout' is missing in type '{ fetch: { (input: RequestInfo | URL, init?: RequestInit | undefined): Promise<Response>; (input: string | Request | URL, init?: RequestInit | undefined): Promise<Response>; }; openWhenHidden: true; body: string; }' but required in type 'Pick<FetchEventSourceInit, "timeout" | "headers" | "body" | "cache" | "credentials" | "fetch" | "integrity" | "keepalive" | "method" | "mode" | "openWhenHidden" | "redirect" | "referrer" | "referrerPolicy" | "window">'.ts(2741)

