### PR TITLE
chore(example): update lobby example with disconnect, reconnect

### DIFF
--- a/src/routes/room/+page.js
+++ b/src/routes/room/+page.js
@@ -1,7 +1,7 @@
 import { catName } from './cat-name'
 import { orPrevious, reconnectingSource } from './sse-utils'
 
-export async function load({ parent }) {
+export async function load() {
   const id = catName()
 
   const connection = reconnectingSource(`/room`, {
@@ -15,7 +15,6 @@ export async function load({ parent }) {
   const usersInLobby = connection.select('usersInLobby').json(orPrevious)
 
   return {
-    ...(await parent()),
     id,
     usersInRoom,
     usersInLobby,

--- a/src/routes/room/mock-db.server.js
+++ b/src/routes/room/mock-db.server.js
@@ -46,13 +46,10 @@ export function findMatchingId(users, id) {
  * @template {{id: string}} T
  * @param {import('svelte/store').Writable<T[]>} store
  * @param {T} update
- * @returns {T | undefined}
  */
 export function updateStore(store, update) {
-  let object
-
   store.update(function upsert(objects) {
-    object = findMatchingId(objects, update.id)
+    const object = findMatchingId(objects, update.id)
     if (object) {
       Object.assign(object, update)
     } else {
@@ -60,6 +57,17 @@ export function updateStore(store, update) {
     }
     return objects
   })
+}
 
-  return object
+/**
+ * @template {{id: string}} T
+ * @param {import('svelte/store').Writable<T[]>} store
+ * @param {string} id
+ */
+export function removeFromStore(store, id) {
+  store.update(function removeFrom(objects) {
+    return objects.filter(function exceptWithId(object) {
+      return object.id !== id
+    })
+  })
 }

--- a/src/routes/room/sse-utils.server.js
+++ b/src/routes/room/sse-utils.server.js
@@ -1,0 +1,79 @@
+/**
+ * Helper function to create a stopper object for SSE events.
+ *
+ * @param {string} route_id
+ * @param {import('$lib').Connection['emit']} emit
+ * @param {import('$lib').Connection['lock']} lock
+ *
+ * @example
+ * export function POST({ route, request }) {
+ *   return events({
+ *     request,
+ *     start({ emit, lock }) {
+ *       const stopper = eventStopper(route.id, emit, lock)
+ *
+ *       const unsub = databaseListener.subscribe(function notify(event) {
+ *         if (event.type === 'new') {
+ *           const { error } = emit('event', JSON.stringify(event))
+ *           if (error) {
+ *             return stopper.stop(error)
+ *           }
+ *         } else if (event.type === 'end') {
+ *           return stopper.stop()
+ *         } else {
+ *           return stopper.stop('Unexpected error')
+ *         }
+ *       })
+ *
+ *       stopper.push(unsub)
+ *
+ *       return stopper.onStop
+ *     }
+ *   })
+ * }
+ */
+export function eventStopper(route_id, emit, lock) {
+  /** @type {(() => void)[]} */
+  const stopFunctions = []
+
+  return {
+    /**
+     * Appends a callback to run when the stopper is stopped.
+     * @param {() => void} func
+     */
+    push(func) {
+      stopFunctions.push(func)
+    },
+
+    /**
+     * Calls all functions in the stopper. Expected usage is that this will be\
+     * returned at the end of the `start` scope of the `events` function,
+     * instead of being called directly.
+     */
+    onStop() {
+      for (const fn of stopFunctions) {
+        try {
+          console.debug('Stopping SSE @', route_id)
+          fn()
+        } catch (err) {
+          console.error('Error stopping SSE @', route_id, err)
+        }
+      }
+    },
+
+    /**
+     * Emits a `stop` event to the client, then locks the connection. If a
+     * message is provided, it will be pushed to the client as an error message.
+     */
+    stop(message = '') {
+      // Include timestamp with message to ensure Svelte reactivity
+      const { error } = emit('stop', `${new Date().getTime()}: ${message}`)
+      if (error && error.message !== 'Client disconnected from the stream.') {
+        console.error('Error stopping SSE @', route_id, error)
+      }
+      lock.set(false)
+
+      return this.onStop
+    },
+  }
+}

--- a/src/routes/room/waiting-lobby/+page.js
+++ b/src/routes/room/waiting-lobby/+page.js
@@ -1,7 +1,7 @@
 import { catName } from '../cat-name'
-import { orPrevious, reconnectingSource } from '../sse-utils'
+import { reconnectingSource, orPrevious } from '../sse-utils'
 
-export async function load({ parent }) {
+export function load() {
   const id = catName()
 
   const connection = reconnectingSource(`/room/waiting-lobby`, {
@@ -11,5 +11,5 @@ export async function load({ parent }) {
   /** @type {import('svelte/store').Readable<import('../mock-db.server').User | null>} */
   const waitingUser = connection.select('waitingUser').json(orPrevious)
 
-  return { ...(await parent()), id, waitingUser, connection }
+  return { id, waitingUser, connection }
 }

--- a/src/routes/room/waiting-lobby/+page.svelte
+++ b/src/routes/room/waiting-lobby/+page.svelte
@@ -19,12 +19,14 @@
 
 <p>You are {data.id}, connection status {$status}</p>
 
-{#if !$waitingUser}
+{#if $status.includes('connecting')}
   <p>Connecting...</p>
-{:else if $waitingUser.approved === false}
+{:else if $waitingUser?.approved === false}
   <p>You have been denied access to the room.</p>
-{:else}
+{:else if $status === 'connected'}
   <p>Waiting to be let into the room...</p>
+{:else}
+  <p>Disconnected.</p>
 {/if}
 
 {#if $status === 'closed'}


### PR DESCRIPTION
Previously, I had the `reconnect()` callbacks in this example commented out.

With 0.12.10 released, I was able to continue testing and fix server-dispatched disconnect, reconnection.

I am planning on one additional set of changes to handle "unhappy path" scenarios - back-off on reconnection, handle HTTP errors with status code, etc.