### PR TITLE
fix: escape cached source key non-latin1 characters

### DIFF
--- a/src/lib/source.js
+++ b/src/lib/source.js
@@ -118,7 +118,7 @@ export function source(
 
   let key = ''
   if (cache) {
-    key = btoa(JSON.stringify({ from, options }))
+    key = btoa(encodeURIComponent(JSON.stringify({ from, options })))
     const cachedSource = cachedSources.get(key)
     if (cachedSource) {
       return cachedSource


### PR DESCRIPTION
An error occurs when calculating the key for a cached source if the serialized options object contain characters outside of the Latin1 range.

> Uncaught InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.