### PR TITLE
fix: add call to onerror on an error

### DIFF
--- a/src/lib/fetchEventSource.js
+++ b/src/lib/fetchEventSource.js
@@ -239,6 +239,9 @@ export function fetchEventSource(input, init = {}) {
         resolve()
       } catch (error) {
         if (!controller.signal.aborted) {
+          if (init.onerror) {
+            onerror(error);
+          }
           controller.abort()
           reject(error)
           return


### PR DESCRIPTION
This fixes issue #73 

The onerror call was missing in the fetchEventSource function.